### PR TITLE
Fix math errors in handy util (#1)

### DIFF
--- a/src/features/handy/utils/getStrokeSpeedAndDistance.test.ts
+++ b/src/features/handy/utils/getStrokeSpeedAndDistance.test.ts
@@ -8,48 +8,48 @@ describe("getStrokeSpeedAndDistance", () => {
     const { speed, stroke, strokeZone } = getStrokeSpeedAndDistance(8);
 
     expect(speed).toBe(maxStrokeSpeed);
-    expect(stroke).toBeCloseTo(24);
-    expect(strokeZone).toEqual({ min: 87, max: 100 });
+    expect(stroke).toBeCloseTo(49);
+    expect(strokeZone).toEqual({ min: 74, max: 100 });
   });
 
   it("should work for 7 bps", () => {
     const { speed, stroke, strokeZone } = getStrokeSpeedAndDistance(7);
 
     expect(speed).toBe(maxStrokeSpeed);
-    expect(stroke).toBeCloseTo(27);
-    expect(strokeZone).toEqual({ min: 85, max: 100 });
+    expect(stroke).toBeCloseTo(57);
+    expect(strokeZone).toEqual({ min: 70, max: 100 });
   });
 
   it("should work for 6 bps", () => {
     const { speed, stroke, strokeZone } = getStrokeSpeedAndDistance(6);
 
     expect(speed).toBe(maxStrokeSpeed);
-    expect(stroke).toBeCloseTo(32);
-    expect(strokeZone).toEqual({ min: 83, max: 100 });
+    expect(stroke).toBeCloseTo(66);
+    expect(strokeZone).toEqual({ min: 65, max: 100 });
   });
 
   it("should work for 5 / sec", () => {
     const { speed, stroke, strokeZone } = getStrokeSpeedAndDistance(5);
 
     expect(speed).toBe(maxStrokeSpeed);
-    expect(stroke).toBeCloseTo(39);
-    expect(strokeZone).toEqual({ min: 80, max: 100 });
+    expect(stroke).toBeCloseTo(79);
+    expect(strokeZone).toEqual({ min: 58, max: 100 });
   });
 
   it("should work for 4 / sec", () => {
     const { speed, stroke, strokeZone } = getStrokeSpeedAndDistance(4);
 
     expect(speed).toBe(maxStrokeSpeed);
-    expect(stroke).toBeCloseTo(48);
-    expect(strokeZone).toEqual({ min: 75, max: 100 });
+    expect(stroke).toBeCloseTo(99);
+    expect(strokeZone).toEqual({ min: 48, max: 100 });
   });
 
   it("should work for 3 / sec", () => {
     const { speed, stroke, strokeZone } = getStrokeSpeedAndDistance(3);
 
     expect(speed).toBe(maxStrokeSpeed);
-    expect(stroke).toBeCloseTo(65);
-    expect(strokeZone).toEqual({ min: 66, max: 100 });
+    expect(stroke).toBeCloseTo(133);
+    expect(strokeZone).toEqual({ min: 31, max: 100 });
   });
 
   it("should work for 2 / sec", () => {

--- a/src/features/handy/utils/getStrokeSpeedAndDistance.ts
+++ b/src/features/handy/utils/getStrokeSpeedAndDistance.ts
@@ -22,7 +22,7 @@ export default function getStrokeSpeedAndDistance(bps: number) {
 
   // Shorten stroke distance to increase BPS
   if (bps > fastestBps) {
-    stroke = maxStrokeSpeed / (bps * fastestBps);
+    stroke = (maxStrokeLength * fastestBps) / bps;
     strokeZone.min = Math.trunc(
       ((maxStrokeLength - stroke) / maxStrokeLength) * 100
     );


### PR DESCRIPTION
Fix math errors in handy utility

Stroke zone was computed incorrectly.
Also, update the tests

## Proposed changes

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe):


## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
